### PR TITLE
Fix custom baseUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ I recommend using a `resize` number [already used](https://github.com/k-next/kir
 If you want the images to be queried from a different location than the `assets/images` folder, you can set the `baseUrl` option in your `config.php` file to whatever folder you'd like. For example:
 
 ```php
-'sylvainjule.imageboxes.baseUrl' => '{{ kirby.url("assets") }}/my-custom-folder',
+'sylvainjule.imageboxes.baseUrl' => 'assets/my-custom-folder',
 ```
 
 <br/>

--- a/lib/options/imageboxes-options.php
+++ b/lib/options/imageboxes-options.php
@@ -7,7 +7,7 @@ class ImageBoxesOptions extends \Kirby\Option\Options {
         $collection = new static();
 
         // We format the correct image url here ↓
-        $baseUrl = option('sylvainjule.imageboxes.baseUrl') ?? kirby()->url('assets') . '/images';
+        $baseUrl = url(option('sylvainjule.imageboxes.baseUrl', 'assets/images'));
         $baseUrl = rtrim($baseUrl, '/');
 
         foreach($items as $key => $option) {


### PR DESCRIPTION
The custom folder path option does not work with query information in kirby 4 so I've modified the $baseUrl logic to create the url directly and moved the fallback to the option(). So now you just need to add the custom path to the config option.